### PR TITLE
fix $xmlElement->addChild() の第二引数に & を含むと unterminated entity referen…

### DIFF
--- a/src/ExcelSetTrait.php
+++ b/src/ExcelSetTrait.php
@@ -296,7 +296,7 @@ trait ExcelSetTrait
 
         foreach ($this->addSharedString as $value) {
             $addString = $sharedXml->addChild('si');
-            $addString->addChild('t', $value);
+            $addString->addChild('t', str_replace('&', '&amp;', $value));
         }
 
         $this->worksheetXml[$this->sharedName] = $sharedXml;
@@ -305,7 +305,7 @@ trait ExcelSetTrait
     private function appendChild(\SimpleXMLElement $target, \SimpleXMLElement $addElement)
     {
         if ('' !== strval($addElement)) {
-            $child = $target->addChild($addElement->getName(), strval($addElement));
+            $child = $target->addChild($addElement->getName(), str_replace('&', '&amp;', strval($addElement)));
         } else {
             $child = $target->addChild($addElement->getName());
         }


### PR DESCRIPTION
外部リンクを含むエクセルファイルを編集した際にエラーが発生

DOMXPath では nodeValue に & を含む文字列を代入できず、
unterminated entity reference エラーが発生するため、
addChild() の第二引数の '&' を '&amp;' に置き換える処理を追加