### PR TITLE
fix Content-Disposition ヘッダーに inline 指定を追加

### DIFF
--- a/src/ExcelSetTrait.php
+++ b/src/ExcelSetTrait.php
@@ -58,7 +58,7 @@ trait ExcelSetTrait
 
         return response($this->generate())
             ->header('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
-            ->header('Content-Disposition', 'filename*=UTF-8\'\''.$filename)
+            ->header('Content-Disposition', 'inline;filename*=UTF-8\'\''.$filename)
             ->header('Cache-Control', 'max-age=0');
     }
 


### PR DESCRIPTION
省略していると Chrome / Edge で filename 指定が無視されるため、Content-Disposition ヘッダーに inline 指定を追加